### PR TITLE
Refactors spacing in schedule views

### DIFF
--- a/FarmaciasDeGuardia/Views/DayScheduleView.swift
+++ b/FarmaciasDeGuardia/Views/DayScheduleView.swift
@@ -37,15 +37,7 @@ struct DayScheduleView: View {
                         .font(.title2)
                         .fontWeight(.medium)
                 }
-                .padding(.bottom, 5)
-                
-                // Region Info section (just the label, no duplicate name)
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Región")
-                        .font(.headline)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.bottom)
+                .padding(.bottom, 20)
                 
                 // Pharmacy section with header
                 VStack(alignment: .leading, spacing: 12) {

--- a/FarmaciasDeGuardia/Views/ScheduleContentView.swift
+++ b/FarmaciasDeGuardia/Views/ScheduleContentView.swift
@@ -29,15 +29,7 @@ struct ScheduleContentView: View {
                         .font(.title2)
                         .fontWeight(.medium)
                 }
-                .padding(.bottom, 5)
-                
-                // Region Info section (just the label, no duplicate name)
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Región")
-                        .font(.headline)
-                        .foregroundColor(.secondary)
-                }
-                .padding(.bottom)
+                .padding(.bottom, 20)
                 
                 // Pharmacy section with header
                 VStack(alignment: .leading, spacing: 12) {

--- a/FarmaciasDeGuardia/Views/ZBSScheduleView.swift
+++ b/FarmaciasDeGuardia/Views/ZBSScheduleView.swift
@@ -135,15 +135,7 @@ struct ZBSScheduleView: View {
                                     .font(.title2)
                                     .fontWeight(.medium)
                             }
-                            .padding(.bottom, 5)
-                            
-                            // ZBS Info (just the label, no duplicate name)
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Zona Básica de Salud")
-                                    .font(.headline)
-                                    .foregroundColor(.secondary)
-                            }
-                            .padding(.bottom)
+                            .padding(.bottom, 20)
                             
                             // Pharmacies for this ZBS on selected date
                             VStack(alignment: .leading, spacing: 12) {


### PR DESCRIPTION
Adjusts the spacing below the date title in the day, schedule, and ZBS schedule views.

Removes the region/ZBS info section as it was deemed redundant.
Increases bottom padding for visual consistency.
